### PR TITLE
Feature: enable AES encryption / decryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "pytron"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pytron"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/pytron-example/README.md
+++ b/pytron-example/README.md
@@ -18,6 +18,11 @@ This example demonstrates how to use the `pytron` tool to:
 pytron zip -o example.zip
 ```
 
+With AES encryption
+```
+pytron zip -o example.zip -p hello-world
+```
+
 ### Running scripts
 
 Run a script directly:
@@ -43,6 +48,11 @@ pytron run main.py --custom-flag
 Run a script from a zip file:
 ```
 pytron run example.zip main.py
+```
+
+Run a script from an encrypted zip file:
+```
+pytron run example.zip main.py --password your-password
 ```
 
 Pass arguments to both uv and the script:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub enum Commands {
     },
 
     #[command(
-        override_usage = "pytron run [UV_ARGS] [ZIPFILE] [SCRIPT] [SCRIPT_ARGS]...",
+        override_usage = "pytron run [UV_ARGS] [ZIPFILE] [PASSWORD] [SCRIPT] [SCRIPT_ARGS]...",
         about = "Run a script - either directly or from a zip archive",
         long_about = "Run a script - either directly or from a zip archive\n\nArguments are separated using a double-dash (--) or by specifying a script/zipfile path:\n  - Arguments before -- or before the zipfile path are passed to uv run\n  - Arguments after -- or after the zipfile path are passed to the script\n\nSpecial flags:\n  -h/--help: Show this help message (pytron's help)\n  -hh/--uv-run-help: Show uv's help message"
     )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub enum Commands {
     },
 
     #[command(
-        override_usage = "pytron run [UV_ARGS] [ZIPFILE] [PASSWORD] [SCRIPT] [SCRIPT_ARGS]...",
+        override_usage = "pytron run [UV_ARGS] [ZIPFILE] [SCRIPT] [SCRIPT_ARGS]...",
         about = "Run a script - either directly or from a zip archive",
         long_about = "Run a script - either directly or from a zip archive\n\nArguments are separated using a double-dash (--) or by specifying a script/zipfile path:\n  - Arguments before -- or before the zipfile path are passed to uv run\n  - Arguments after -- or after the zipfile path are passed to the script\n\nSpecial flags:\n  -h/--help: Show this help message (pytron's help)\n  -hh/--uv-run-help: Show uv's help message"
     )]
@@ -69,6 +69,8 @@ pub enum Commands {
 
         /// Additional AES decryption password
         #[arg(
+            short,
+            long,
             help="AES Decryption password to decrypt the given ZIP file",
             long_help="AES Decryption password to decrypt the given ZIP file\nThis depends on if the file has been encrypted before\n Example: \n --password hello-world")]
         password: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
 
         while i < args.len() {
 
-            if args[i] == "--password" {
+            if args[i] == "--password" || args[i] == "-p" {
                 // next element must be the password
                 if i + 1 < args.len() {
                     password = Some(args[i + 1].clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,8 +84,28 @@ fn main() {
             if args[i] == "--uv-run-help" || args[i] == "-hh" {
                 // Convert to standard help flag for uv
                 uv_args.push("--help".to_string());
-                i += 1;
-                continue;
+                // Skip zip file execution completely when -hh is used
+                println!("Running: uv run --help");
+                // Check if uv is installed or download it if needed
+                if !pytron::is_uv_installed() {
+                    println!("uv not found. Attempting to download...");
+                    match pytron::download_uv() {
+                        Ok(path) => println!("Downloaded uv to: {}", path.display()),
+                        Err(err) => {
+                            eprintln!("Failed to download uv: {}. Please install uv manually (https://github.com/astral-sh/uv)", err);
+                            exit(1);
+                        }
+                    }
+                }
+                // Run uv directly with help flag
+                let status = pytron::get_uv_command().args(&["run", "--help"]).status();
+                match status {
+                    Ok(status) => exit(status.code().unwrap_or(1)),
+                    Err(err) => {
+                        eprintln!("Error running uv: {}", err);
+                        exit(1);
+                    }
+                }
             }
 
             // Everything else before separator or script name is a uv flag

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -8,13 +8,15 @@ fn test_cli_parsing() {
     let args = vec!["pytron", "zip"];
     let cli = Cli::parse_from(args);
 
-    if let Commands::Zip { directory, output, ignore_patterns } = cli.command {
+    if let Commands::Zip { directory, output, ignore_patterns, password } = cli.command {
         assert_eq!(directory, ".", "Default directory should be '.'");
         assert_eq!(
             output, "robot.zip",
             "Default output file should be 'robot.zip'"
         );
         assert!(ignore_patterns.is_none(), "Default ignore_patterns should be None");
+        assert!(password.is_none(), "No password expected");
+
     } else {
         panic!("Expected Zip command");
     }
@@ -23,7 +25,7 @@ fn test_cli_parsing() {
     let args = vec!["pytron", "zip", "--ignore-patterns", "node_modules,*.log,*.tmp"];
     let cli = Cli::parse_from(args);
 
-    if let Commands::Zip { directory, output, ignore_patterns } = cli.command {
+    if let Commands::Zip { directory, output, ignore_patterns, password } = cli.command {
         assert_eq!(directory, ".", "Default directory should be '.'");
         assert_eq!(
             output, "robot.zip",
@@ -35,6 +37,8 @@ fn test_cli_parsing() {
         assert_eq!(patterns[0], "node_modules", "First pattern should be 'node_modules'");
         assert_eq!(patterns[1], "*.log", "Second pattern should be '*.log'");
         assert_eq!(patterns[2], "*.tmp", "Third pattern should be '*.tmp'");
+        assert!(password.is_none(), "No password expected");
+
     } else {
         panic!("Expected Zip command");
     }
@@ -43,7 +47,7 @@ fn test_cli_parsing() {
     let args = vec!["pytron", "zip", "--ignore-patterns", ""];
     let cli = Cli::parse_from(args);
 
-    if let Commands::Zip { directory, output, ignore_patterns } = cli.command {
+    if let Commands::Zip { directory, output, ignore_patterns, password } = cli.command {
         assert_eq!(directory, ".", "Default directory should be '.'");
         assert_eq!(
             output, "robot.zip",
@@ -53,6 +57,8 @@ fn test_cli_parsing() {
         let patterns = ignore_patterns.unwrap();
         assert_eq!(patterns.len(), 1, "Expected 1 empty string");
         assert_eq!(patterns[0], "", "Pattern should be empty string");
+        assert!(password.is_none(), "No password expected");
+
     } else {
         panic!("Expected Zip command");
     }
@@ -64,6 +70,7 @@ fn test_cli_parsing() {
     if let Commands::Run {
         zipfile,
         script,
+        password,
         uv_args,
         script_args,
     } = cli.command
@@ -75,23 +82,27 @@ fn test_cli_parsing() {
         assert_eq!(script, "main.py", "Default script should be 'main.py'");
         assert_eq!(uv_args.len(), 0, "No UV arguments expected");
         assert_eq!(script_args.len(), 0, "No script arguments expected");
+        assert!(password.is_none(), "No password expected");
+
     } else {
         panic!("Expected Run command");
     }
 
     // Test the Run command with custom values (all in script_args)
-    let args = vec!["pytron", "run", "custom.zip", "custom.py", "arg1", "arg2"];
+    let args = vec!["pytron", "run", "custom.zip", "custom.py", "fooPass", "arg1", "arg2"];
     let cli = Cli::parse_from(args);
 
     if let Commands::Run {
         zipfile,
         script,
+        password,
         uv_args,
         script_args,
     } = cli.command
     {
         assert_eq!(zipfile, "custom.zip", "Custom zip file name not matched");
         assert_eq!(script, "custom.py", "Custom script name not matched");
+        assert_eq!(password.unwrap(), "fooPass", "Passwort 'fooPass' expected");
         
         // With this structure, arg1 and arg2 are actually captured as UV args
         assert_eq!(uv_args.len(), 2, "Expected 2 UV arguments with this parsing style");
@@ -114,6 +125,7 @@ fn test_cli_parsing() {
     if let Commands::Run {
         zipfile,
         script,
+        password,
         uv_args,
         script_args,
     } = cli.command
@@ -122,6 +134,8 @@ fn test_cli_parsing() {
         assert_eq!(script, "script.py", "Custom script should be 'script.py'");
         assert_eq!(uv_args.len(), 0, "No UV args expected");  
         assert_eq!(script_args.len(), 0, "No script args expected");
+        assert!(password.is_none(), "No password expected");
+
     } else {
         panic!("Expected Run command");
     }

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -89,7 +89,7 @@ fn test_cli_parsing() {
     }
 
     // Test the Run command with custom values (all in script_args)
-    let args = vec!["pytron", "run", "custom.zip", "custom.py", "fooPass", "arg1", "arg2"];
+    let args = vec!["pytron", "run", "-p", "fooPass", "custom.zip", "custom.py", "arg1", "arg2"];
     let cli = Cli::parse_from(args);
 
     if let Commands::Run {

--- a/tests/test_exit_codes.rs
+++ b/tests/test_exit_codes.rs
@@ -54,6 +54,7 @@ fn test_exit_code_handling() {
         test_dir.path().to_str().unwrap(),
         output_zip.to_str().unwrap(),
         None,
+        None,
     )
     .expect("Failed to create test zip file");
 
@@ -122,6 +123,7 @@ fn test_exit_code_forwarding_integration() {
         test_dir.path().to_str().unwrap(),
         output_zip.to_str().unwrap(),
         None,
+        None,
     )
     .expect("Failed to create test zip file");
 
@@ -134,7 +136,7 @@ fn test_exit_code_forwarding_integration() {
     ];
 
     for (script_name, args, expected_code) in &test_cases {
-        let result = pytron::run_from_zip(output_zip.to_str().unwrap(), script_name, &[], args);
+        let result = pytron::run_from_zip(output_zip.to_str().unwrap(), None, script_name, &[], args);
 
         // If the test succeeds, it should return the expected code
         if let Ok(code) = result {

--- a/tests/test_pytron_home.rs
+++ b/tests/test_pytron_home.rs
@@ -109,6 +109,7 @@ fn test_run_from_zip_uses_pytron_home_for_temp() {
         test_dir.path().to_str().unwrap(),
         zip_path.to_str().unwrap(),
         None,
+        None
     )
     .expect("Failed to create zip file");
 
@@ -127,7 +128,7 @@ fn test_run_from_zip_uses_pytron_home_for_temp() {
 
     // Run the script, but since we likely don't have uv installed in our test environment,
     // this will probably fail - but that's okay for this test
-    let _ = pytron::run_from_zip(zip_path.to_str().unwrap(), "test_script.py", &[], &[]);
+    let _ = pytron::run_from_zip(zip_path.to_str().unwrap(),None, "test_script.py", &[], &[]);
 
     // After our run_from_zip call, check that the temp directory still exists
     println!(

--- a/tests/test_pytron_structure.rs
+++ b/tests/test_pytron_structure.rs
@@ -87,6 +87,7 @@ fn test_run_from_zip_temp_directory_creation() {
         test_dir.path().to_str().unwrap(),
         zip_path.to_str().unwrap(),
         None,
+        None,
     ).expect("Failed to create test zip file");
     
     // Prepare for extraction path check and create it
@@ -99,6 +100,7 @@ fn test_run_from_zip_temp_directory_creation() {
     // Even if we can't run the script (no uv), the function should at least create the temp directory
     let _ = pytron::run_from_zip(
         zip_path.to_str().unwrap(),
+        None,
         "simple.py", 
         &[],
         &[],


### PR DESCRIPTION
## Related Issues
Resolves issue #1 

## Description
Adds a new option to encrypt the pytron zip directory using args `-p` or `--password`

## Examples
Zipping files with only password argument
```
pytron zip -p fooPass -o example.zip
```

Run a script within the zip file using only the password argument
```
pytron run -p fooPass example.zip
```

Run a script with uv and script arguments
```
pytron run -v -p fooPass example.zip main.py arg1 arg2
```