### PR TITLE
Feature: clear and show python cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "pytron"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pytron"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/pytron-example/README.md
+++ b/pytron-example/README.md
@@ -65,6 +65,17 @@ Using a double-dash separator with default zip/script:
 pytron run -v -- --script-arg
 ```
 
+### Dealing with cache
+Show all available cache directories in current project
+```
+pytron cache dir
+```
+
+Clear all local cache (including global uv cache)
+```
+pytron cache clear
+```
+
 ## Argument Handling
 
 Arguments are separated in two ways:

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn main() {
                     }
                 }
                 // Run uv directly with help flag
-                let status = pytron::get_uv_command().args(&["run", "--help"]).status();
+                let status = pytron::get_uv_command().args(["run", "--help"]).status();
                 match status {
                     Ok(status) => exit(status.code().unwrap_or(1)),
                     Err(err) => {

--- a/tests/test_cache.rs
+++ b/tests/test_cache.rs
@@ -1,0 +1,89 @@
+use pytron::{delete_python_cache ,show_cache_dirs};
+use tempfile::tempdir;
+use std::fs::{self, File, create_dir_all};
+use std::path::Path;
+
+fn create_file<P: AsRef<Path>>(path: P) {
+    File::create(path).expect("Failed to create file");
+}
+
+fn create_dir_structure(base: &Path, names: &[&str]) {
+    for name in names {
+        let dir = base.join(name);
+        fs::create_dir_all(&dir).unwrap();
+        create_file(dir.join("dummy.pyc")); // dummy cache file
+    }
+}
+
+#[test]
+fn test_delete_python_cache_basic() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    create_dir_structure(root, &["__pycache__", ".pytest_cache", ".venv", "not_cache"]);
+
+    assert!(root.join("__pycache__").exists());
+    assert!(root.join(".pytest_cache").exists());
+    assert!(root.join(".venv").exists());
+
+    delete_python_cache(root).unwrap();
+
+    // Check deletion
+    assert!(!root.join("__pycache__").exists());
+    assert!(!root.join(".pytest_cache").exists());
+    assert!(!root.join(".venv").exists());
+
+    // Check non-cache folder still exists
+    assert!(root.join("not_cache").exists());
+}
+
+#[test]
+fn test_delete_nested_cache_dirs() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    let subdir = root.join("src/module");
+    create_dir_all(&subdir).unwrap();
+    create_dir_structure(&subdir, &["__pycache__", ".pytest_cache"]);
+
+    delete_python_cache(root).unwrap();
+
+    assert!(!subdir.join("__pycache__").exists());
+    assert!(!subdir.join(".pytest_cache").exists());
+}
+
+#[test]
+fn test_show_cache_dirs() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    create_dir_structure(root, &["__pycache__", ".pytest_cache", ".venv"]);
+
+    // Note: Here we just want to ensure it runs. Output would go to stdout.
+    assert_eq!(show_cache_dirs(root).unwrap(), 0);
+}
+
+#[test]
+fn test_delete_python_cache_no_cache_dirs() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    create_dir_structure(root, &["src", "docs"]);
+
+    assert_eq!(delete_python_cache(root).unwrap(), 0);
+    assert!(root.join("src").exists());
+    assert!(root.join("docs").exists());
+}
+
+#[test]
+fn test_ignore_files_and_non_dirs() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    let file_path = root.join("__pycache__"); // should be a file, not a dir
+    File::create(&file_path).unwrap();
+
+    assert!(file_path.is_file());
+    assert_eq!(delete_python_cache(root).unwrap(), 0);
+    assert!(file_path.exists()); // should not be deleted
+}


### PR DESCRIPTION
## Related Issues
Resolves issue #3  

## Description
Adds a new command to view available cache directories and virtual environments with the command ```cache```
- ```clear``` to clear all local cache directories and global uv cache
- ```dir``` to show all available cache directories, virtual environments, and the global uv cache path

## Examples
Show all cache directories
```
pytron cache dir
```

Clear all cache directories
```
pytron cache clear
```